### PR TITLE
Fix python backwards compat issues.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Hatch
         uses: pypa/hatch@install
       - name: Test
-        run: hatch test
+        run: hatch test -i py=${{ matrix.python-version }}
   linting:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,20 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Hatch
+        uses: pypa/hatch@install
+      - name: Test
+        run: hatch test
+  linting:
+    runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -26,9 +39,16 @@ jobs:
         uses: pypa/hatch@install
       - name: Lint
         run: hatch fmt --check
-      # Run just the unit tests
-      # - name: Test
-      #   run: hatch test
+  integration:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install Hatch
+        uses: pypa/hatch@install
       - name: Integration Tests
         run: hatch run integration:test
       - name: Combine Coverage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,10 +28,10 @@ jobs:
         run: hatch fmt --check
       - name: Tests
         run: hatch run +py=${{ matrix.python-version }} integration:test
-      # - name: Combine Coverage
-      #   run: hatch run integration:cov-combine
-      # - name: Report Coverage
-      #   run: hatch run integration:cov-report
+      - name: Combine Coverage
+        run: hatch run +py=${{ matrix.python-version }} integration:cov-combine
+      - name: Report Coverage
+        run: hatch run +py=${{ matrix.python-version }} integration:cov-report
       # TODO: use cov-total to update a coverage badge.
       # - name: Report Coverage
       #   run: hatch run integration:cov-total

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
       # - name: Report Coverage
       #   run: hatch run integration:cov-total
       - name: Report Coverage
-        run: hatch run integration:cov-lcov
+        run: hatch run +py=${{ matrix.python-version }} integration:cov-lcov
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2.3.4
     services:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,20 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Hatch
-        uses: pypa/hatch@install
-      - name: Test
-        run: hatch test -i py=${{ matrix.python-version }}
-  linting:
-    runs-on: ubuntu-latest
-    needs: test
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -39,18 +26,8 @@ jobs:
         uses: pypa/hatch@install
       - name: Lint
         run: hatch fmt --check
-  integration:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Install Hatch
-        uses: pypa/hatch@install
-      - name: Integration Tests
-        run: hatch run integration:test
+      - name: Tests
+        run: hatch run +py=${{ matrix.python-version }} integration:test
       - name: Combine Coverage
         run: hatch run integration:cov-combine
       - name: Report Coverage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,10 +28,10 @@ jobs:
         run: hatch fmt --check
       - name: Tests
         run: hatch run +py=${{ matrix.python-version }} integration:test
-      - name: Combine Coverage
-        run: hatch run integration:cov-combine
-      - name: Report Coverage
-        run: hatch run integration:cov-report
+      # - name: Combine Coverage
+      #   run: hatch run integration:cov-combine
+      # - name: Report Coverage
+      #   run: hatch run integration:cov-report
       # TODO: use cov-total to update a coverage badge.
       # - name: Report Coverage
       #   run: hatch run integration:cov-total

--- a/denvr/session.py
+++ b/denvr/session.py
@@ -39,7 +39,7 @@ class Session:
         )
 
     def request(self, method, path, **kwargs):
-        url = os.path.join(self.config.server, *filter(None, path.split('/')))
+        url = os.path.join(self.config.server, *filter(None, path.split("/")))
         logger.debug("Request: self.session.request(%s, %s, **%s", method, url, kwargs)
         resp = self.session.request(method, url, **kwargs)
         resp.raise_for_status()

--- a/denvr/session.py
+++ b/denvr/session.py
@@ -39,7 +39,7 @@ class Session:
         )
 
     def request(self, method, path, **kwargs):
-        url = os.path.join(self.config.server, os.path.splitroot(path)[-1])
+        url = os.path.join(self.config.server, *filter(None, path.split('/')))
         logger.debug("Request: self.session.request(%s, %s, **%s", method, url, kwargs)
         resp = self.session.request(method, url, **kwargs)
         resp.raise_for_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -36,8 +37,8 @@ allow-direct-references = true
 path = "denvr/__about__.py"
 
 [tool.hatch.envs.default]
-dependencies = ["jinja2", "keyring", "requests", "toml"]
-path = "venv"
+dependencies = ["jinja2", "requests", "toml"]
+# path = "venv"
 
 [tool.hatch.envs.types]
 extra-dependencies = ["mypy>=1.0.0"]
@@ -62,9 +63,12 @@ extra-args = ["-m", "not integration"]
 
 # Run full tests including integration
 [tool.hatch.envs.integration]
-dependencies = ["coverage", "pytest"]
+dependencies = ["coverage", "pytest", "pytest-cov"]
+[[tool.hatch.envs.integration.matrix]]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 [tool.hatch.envs.integration.scripts]
-test = "coverage run --data-file .coverage -m pytest tests"
+# test = "python{matrix:python} -m coverage run --data-file .coverage -m pytest tests"
+test = 'pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=pkg --cov=tests'
 cov-combine = "coverage combine"
 cov-report = "coverage report -m"
 cov-total = "coverage report -m --format=total"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,7 @@ dependencies = ["coverage", "pytest", "pytest-cov"]
 [[tool.hatch.envs.integration.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 [tool.hatch.envs.integration.scripts]
-# test = "python{matrix:python} -m coverage run --data-file .coverage -m pytest tests"
-test = 'pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=pkg --cov=tests'
+test = "coverage run --data-file .coverage -m pytest tests"
 cov-combine = "coverage combine"
 cov-report = "coverage report -m"
 cov-total = "coverage report -m --format=total"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,7 +35,7 @@ def test_config(mock_post):
     username = "test@foobar.com"
     password = "test.foo.bar.baz"
     """
-    kwargs = {'delete_on_close': False } if sys.version_info >=(3, 12) else {'delete': False}
+    kwargs = {"delete_on_close": False} if sys.version_info >= (3, 12) else {"delete": False}
     with tempfile.NamedTemporaryFile(**kwargs) as fp:
         fp.write(content.encode())
         fp.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 # We just need to mock the Auth object
+import sys
 import tempfile
 from unittest.mock import Mock, patch
 
@@ -34,7 +35,8 @@ def test_config(mock_post):
     username = "test@foobar.com"
     password = "test.foo.bar.baz"
     """
-    with tempfile.NamedTemporaryFile(delete_on_close=False) as fp:
+    kwargs = {'delete_on_close': False } if sys.version_info >=(3, 12) else {'delete': False}
+    with tempfile.NamedTemporaryFile(**kwargs) as fp:
         fp.write(content.encode())
         fp.close()
 


### PR DESCRIPTION
To start it looks like our CI matrix wasn't actually testing on the python versions I thought.

1. Looks like the hatch integration tests weren't using the build matrix python version by default.
2. Rather than running our integration tests for each python version we can just run the unit tests which will hopefully just work... otherwise we'll need to manually specify the version to run.
3. Moved the linting and integration tests into separate jobs which may also fix the mockserver service timeout issues.

Once the CI workflow is fixed then we can work on ensure the python code actually runs on all the specified versions.