### PR TITLE
Improve error messages.

### DIFF
--- a/denvr/session.py
+++ b/denvr/session.py
@@ -2,10 +2,9 @@ import logging
 
 import requests
 from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
 
 from denvr.config import Config
-from denvr.utils import snakecase
+from denvr.utils import snakecase, raise_for_status
 
 logger = logging.getLogger(__name__)
 
@@ -24,29 +23,20 @@ class Session:
         # Set the auth, header and retry strategy for the session object
         self.session.auth = self.config.auth
         self.session.headers.update({"Content-Type": "application/json"})
-        self.session.mount(
-            self.config.server,
-            HTTPAdapter(
-                max_retries=Retry(
-                    total=self.config.retries,
-                    # TODO: Consider making these configurable in the future?
-                    backoff_factor=0.1,
-                    status_forcelist=(408, 425, 429, 500, 502, 503, 504),
-                    allowed_methods={"GET", "PUT", "POST", "DELETE"},
-                )
-            ),
-        )
+        self.session.mount(self.config.server, HTTPAdapter(max_retries=self.config.retries))
 
     def request(self, method, path, **kwargs):
         url = "/".join([self.config.server, *filter(None, path.split("/"))])
         logger.debug("Request: self.session.request(%s, %s, **%s", method, url, kwargs)
         resp = self.session.request(method, url, **kwargs)
-        resp.raise_for_status()
+        raise_for_status(resp)
         result = resp.json()
         logger.debug("Response: resp.json() -> %s", result)
+
         # According to the spec we should just be return result and not {"result": result }?
         # For mock-server testing purposes we'll support both.
         result = result.get("result", result) if isinstance(result, dict) else result
+
         # Standardize the response keys to snakecase if it's a dict'
         if isinstance(result, dict):
             return {snakecase(k): v for k, v in result.items()}

--- a/denvr/utils.py
+++ b/denvr/utils.py
@@ -1,3 +1,11 @@
+import logging
+import typing
+
+from requests import JSONDecodeError, HTTPError, Response
+
+logger = logging.getLogger(__name__)
+
+
 def snakecase(text: str) -> str:
     """
     Convert camelcase and titlecase strings to snakecase.
@@ -9,3 +17,52 @@ def snakecase(text: str) -> str:
         str: The converted string.
     """
     return "".join(["_" + i.lower() if i.isupper() else i for i in text]).lstrip("_")
+
+
+# We'll disable mypy for this function since we're largely trying to match the requests code.
+@typing.no_type_check
+def raise_for_status(resp: Response):
+    """
+    Given a response object return either resp.json() or resp.json()["error"].
+    This is basically just a modified version of
+    https://requests.readthedocs.io/en/latest/_modules/requests/models/#Response.raise_for_status
+
+    Args:
+        resp (Response): The request response object.
+
+    Returns:
+        The request response error.
+    """
+    # Early exit if everything is fine.
+    if resp.status_code < 400:
+        return None
+
+    # Start building the error message that we'll raise
+    if isinstance(resp.reason, bytes):
+        # We attempt to decode utf-8 first because some servers
+        # choose to localize their reason strings. If the string
+        # isn't utf-8, we fall back to iso-8859-1 for all other
+        # encodings. (See PR #3538)
+        try:
+            reason = resp.reason.decode("utf-8")
+        except UnicodeDecodeError:
+            reason = resp.reason.decode("iso-8859-1")
+    else:
+        reason = resp.reason
+
+    details = ""
+    try:
+        details = " - {}".format(resp.json()["error"]["message"])
+    except JSONDecodeError:
+        logger.debug("Failed to decode JSON response")
+    except KeyError:
+        logger.debug("Failed to extract error message from response")
+
+    msg = ""
+    if 400 <= resp.status_code < 500:
+        msg = f"{resp.status_code} Client Error: {reason} for url: {resp.url}{details}"
+    elif 500 <= resp.status_code < 600:
+        msg = f"{resp.status_code} Server Error: {reason} for url: {resp.url}{details}"
+
+    if msg:
+        raise HTTPError(msg, response=resp)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import pytest
+from requests.exceptions import HTTPError, JSONDecodeError
+
+from denvr.utils import raise_for_status
+
+
+def test_raise_for_status_pass():
+    response = MagicMock()
+    response.status_code = 200
+    result = raise_for_status(response)
+    assert result is None
+
+
+def test_raise_for_status_error():
+    response = MagicMock()
+    response.status_code = 500
+    response.url = "http://localhost:9000"
+    response.reason = "Server Error"
+    with pytest.raises(HTTPError):
+        raise_for_status(response)
+
+    # Also handle different encoding for reason
+    response.reason = "Server Error".encode("utf-8")
+    with pytest.raises(HTTPError):
+        raise_for_status(response)
+
+    response.reason = "Server Error".encode("iso-8859-1")
+    with pytest.raises(HTTPError):
+        raise_for_status(response)
+
+
+def test_raise_for_status_error_with_details():
+    response = MagicMock()
+    response.status_code = 404
+    response.url = "http://localhost:9000"
+    response.reason = "Not Found"
+    response.json = lambda: {
+        "error": {"message": "These are not the droids you're looking for."}
+    }
+    with pytest.raises(HTTPError, match="droids"):
+        raise_for_status(response)
+
+    # Handle fallback cases for no json or unknown schema
+    # TODO: Use caplog for these cases.
+    # https://docs.pytest.org/en/latest/how-to/logging.html#caplog-fixture
+    response.json = lambda: {"err": "These are not the droids you're looking for."}
+    with pytest.raises(HTTPError):
+        raise_for_status(response)
+
+    # A bit of a hack cause we can't raise an exception from a lambda function
+    response.json = lambda: (_ for _ in ()).throw(JSONDecodeError("err", "", 0))
+    with pytest.raises(HTTPError):
+        raise_for_status(response)


### PR DESCRIPTION
1. Simplify the retry logic to avoid retries on errors that might be important. For example, a lot of client-side errors produce 500 errors.
3. Whenever possible, extract "error" -> "message" from error responses to provide more details on what went wrong.