### PR TITLE
Fixes max recursion issue in apigen.py on recent swagger.json file

### DIFF
--- a/denvr/api/v1/servers/virtual.py
+++ b/denvr/api/v1/servers/virtual.py
@@ -110,7 +110,7 @@ class Client:
             client.create_server(
                 name="my-denvr-vm",
                 rpool="reserved-denvr",
-                vpc="denvr-vpc",
+                vpc="denvr",
                 configuration="A100_40GB_PCIe_1x",
                 cluster="Hou1",
                 ssh_keys=["string"],

--- a/tests/api/v1/servers/test_virtual.py
+++ b/tests/api/v1/servers/test_virtual.py
@@ -186,7 +186,7 @@ def test_create_server():
     client_kwargs: Dict[str, Any] = {
         "name": "my-denvr-vm",
         "rpool": "reserved-denvr",
-        "vpc": "denvr-vpc",
+        "vpc": "denvr",
         "configuration": "A100_40GB_PCIe_1x",
         "cluster": "Hou1",
         "ssh_keys": ["string"],
@@ -206,7 +206,7 @@ def test_create_server():
             "json": {
                 "name": "my-denvr-vm",
                 "rpool": "reserved-denvr",
-                "vpc": "denvr-vpc",
+                "vpc": "denvr",
                 "configuration": "A100_40GB_PCIe_1x",
                 "cluster": "Hou1",
                 "ssh_keys": ["string"],
@@ -241,7 +241,7 @@ def test_create_server_httpserver(httpserver: HTTPServer):
     client_kwargs: Dict[str, Any] = {
         "name": "my-denvr-vm",
         "rpool": "reserved-denvr",
-        "vpc": "denvr-vpc",
+        "vpc": "denvr",
         "configuration": "A100_40GB_PCIe_1x",
         "cluster": "Hou1",
         "ssh_keys": ["string"],
@@ -261,7 +261,7 @@ def test_create_server_httpserver(httpserver: HTTPServer):
             "json": {
                 "name": "my-denvr-vm",
                 "rpool": "reserved-denvr",
-                "vpc": "denvr-vpc",
+                "vpc": "denvr",
                 "configuration": "A100_40GB_PCIe_1x",
                 "cluster": "Hou1",
                 "ssh_keys": ["string"],
@@ -298,7 +298,7 @@ def test_create_server_mockserver(mock_config):
     client_kwargs: Dict[str, Any] = {
         "name": "my-denvr-vm",
         "rpool": "reserved-denvr",
-        "vpc": "denvr-vpc",
+        "vpc": "denvr",
         "configuration": "A100_40GB_PCIe_1x",
         "cluster": "Hou1",
         "ssh_keys": ["string"],


### PR DESCRIPTION
Additional internal endpoints added a few weeks ago started causing the nightly apigen.py script to start failing. The issue is that the deeply nested nature of the new internal schemas started hitting Python's max recursion depth of 1000 while flattening the refs.

For now, the fix is just to filter out those schemas prior to flattening the refs.

Changes:

1. Filter out components not just paths
2. Reverse the order of filtering and flattening